### PR TITLE
Feature/lightcone isomorphism

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ return res
 
 Requires `pynauty 0.6.0`, which can be installed by following the instructions [here](https://web.cs.dal.ca/~peter/software/pynauty/html/install.html)
 
-```
+```python
 import networkx as nx
 import numpy as np
 from qtensor import QAOAQtreeSimulatorSymmetryAccelerated, QtreeQAOAComposer

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ https://hub.docker.com/repository/docker/danlkv/qtensor
 ## Usage
 
 ```python
+import networkx as nx
+import numpy as np
 from qtensor import QAOA_energy
 
 G = nx.random_regular_graph(3, 10)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ return res
 
 ```
 
+#### Use lightcone symmetry to accelerate the energy evaluation
+
+Requires `pynauty 0.6.0`, which can be installed by following the instructions [here](https://web.cs.dal.ca/~peter/software/pynauty/html/install.html)
+
+```
+import networkx as nx
+import numpy as np
+from qtensor import QAOAQtreeSimulatorSymmetryAccelerated, QtreeQAOAComposer
+
+G = nx.random_regular_graph(3, 100)
+gamma, beta = [np.pi/3], [np.pi/2]
+
+sym = QAOAQtreeSimulatorSymmetryAccelerated(QtreeQAOAComposer)
+
+E = sym.energy_expectation(G, gamma, beta)
+```
+
 ### Useful features
 
 - raise ValueError if treewidth is too large:

--- a/qtensor/__init__.py
+++ b/qtensor/__init__.py
@@ -14,6 +14,7 @@ from .OpFactory import QtreeFullBuilder
 from qtensor.Simulate import CirqSimulator, QtreeSimulator
 from qtensor.QAOASimulator import QAOAQtreeSimulator
 from qtensor.QAOASimulator import QAOACirqSimulator
+from qtensor.QAOASimulator import QAOAQtreeSimulatorSymmetryAccelerated
 from qtensor.FeynmanSimulator import FeynmanSimulator
 from qtensor.contraction_backends import PerfNumpyBackend, NumpyBackend
 from qtensor import simplify_circuit

--- a/qtensor/tests/test_lightcone_orbits.py
+++ b/qtensor/tests/test_lightcone_orbits.py
@@ -1,0 +1,16 @@
+import networkx as nx
+import numpy as np
+from qtensor import QAOA_energy, QAOAQtreeSimulatorSymmetryAccelerated, QtreeQAOAComposer
+
+def test_lightcone_energy_value():
+    G = nx.random_regular_graph(3, 100, seed=42)
+    gamma, beta = [np.pi/3], [np.pi/2]
+    
+    E = QAOA_energy(G, gamma, beta)
+    
+    sym = QAOAQtreeSimulatorSymmetryAccelerated(QtreeQAOAComposer)
+    
+    E2 = sym.energy_expectation(G, gamma, beta)
+    
+    assert(np.isclose(E,E2))
+    

--- a/qtensor/tools/lazy_import/__init__.py
+++ b/qtensor/tools/lazy_import/__init__.py
@@ -48,6 +48,7 @@ qiskit_lib = FallbackLasyModule(['qiskit.circuit.library','qiskit.extensions.sta
 mpi4py = LasyModule('mpi4py')
 MPI = LasyModule('mpi4py.MPI')
 networkit = LasyModule('networkit')
+pynauty = LasyModule('pynauty')
 """ can this break something? need to think more
 
 What if user imports qtensor, and then networkit?

--- a/qtensor/tools/lightcone_orbits.py
+++ b/qtensor/tools/lightcone_orbits.py
@@ -1,0 +1,68 @@
+from collections import defaultdict
+import pynauty
+import networkx as nx
+
+from qtensor.utils import get_edge_subgraph
+
+def get_adjacency_dict(G):
+    """Returns adjacency dictionary for G
+    G must be a networkx graph
+    Return format: { n : [n1,n2,...], ... }
+    where [n1,n2,...] is a list of neighbors of n
+    """
+    adjacency_dict = {}
+    for n, neigh_dict in G.adjacency():
+        neigh_list = []
+        for neigh, attr_dict in neigh_dict.items():
+            assert(len(attr_dict) == 0)
+            neigh_list.append(neigh)
+        adjacency_dict[n] = neigh_list
+    return adjacency_dict
+
+
+
+def relabel_edge_first(G, e):
+    """Takes graph G and returns a relabelled graph 
+    such that the vertices in edge e are labelled 0,1
+    and all other vertices are labelled using 
+    consecutive integers
+    """
+    assert(len(e) == 2)
+    mapping = {e[0]: 0, e[1]: 1}
+    i = 2
+    for n in G.nodes():
+        if n not in e:
+            mapping[n] = i
+            i += 1
+    assert(len(mapping) == G.number_of_nodes())
+    return nx.relabel_nodes(G, mapping)
+
+
+def get_edge_orbits_lightcones(G,p):
+    """Takes graph G and number of QAOA steps p
+    returns unique subgraphs that QAOA sees
+    dict: {orbit_id : [list of edges in orbit]} 
+    and maximum number of nodes in a lightcone subgraph
+    if maxnnodes == G.number_of_nodes(), this simply becomes edge orbits
+    """
+    maxnnodes = -1
+
+    eorbits = defaultdict(list)
+    # for each edge construct the light cone subgraph and compute certificate  
+    for e in G.edges():
+        subgraph = relabel_edge_first(get_edge_subgraph(G, e, p), e)
+        maxnnodes = max(maxnnodes, subgraph.number_of_nodes())
+        g = pynauty.Graph(number_of_vertices=subgraph.number_of_nodes(), directed=nx.is_directed(subgraph),
+                    adjacency_dict = get_adjacency_dict(subgraph),
+                    vertex_coloring = [set([0,1]), set(range(2, subgraph.number_of_nodes()))])
+        cert = pynauty.certificate(g)
+        eorbits[cert].append(e)
+
+    eorbits_integer_keys = {}
+    for i, (cert, edges) in enumerate(eorbits.items()):
+        eorbits_integer_keys[i] = edges
+
+    assert(len(eorbits_integer_keys) == len(eorbits))
+    return eorbits_integer_keys, maxnnodes
+
+


### PR DESCRIPTION
Added code to speed up QAOA energy calculations by leveraging the symmetries (redundancies) in the lightcone structure. To verify the speedup, try the following:

```python
import networkx as nx
import numpy as np
from qtensor import QAOA_energy, QAOAQtreeSimulatorSymmetryAccelerated, QtreeQAOAComposer

G = nx.random_regular_graph(3, 100)
gamma, beta = [np.pi/3], [np.pi/2]

E = QAOA_energy(G, gamma, beta)

print(E)

sym = QAOAQtreeSimulatorSymmetryAccelerated(QtreeQAOAComposer)

E2 = sym.energy_expectation(G, gamma, beta)
print(E2)

assert(np.isclose(E,E2))
```

The new dependency is `pynauty`:  https://web.cs.dal.ca/~peter/software/pynauty/html/install.html (see also README.md)