### PR TITLE
added parallel lightcone computation

### DIFF
--- a/qtensor/QAOASimulator.py
+++ b/qtensor/QAOASimulator.py
@@ -123,7 +123,7 @@ class QAOASimulatorSymmetryAccelerated(QAOASimulator):
         p = len(gamma)
         assert(len(beta) == p)
 
-        eorbits, maxnnodes_lightcone = get_edge_orbits_lightcones(G,p)
+        eorbits, _ = get_edge_orbits_lightcones(G,p)
         if len(eorbits) == G.number_of_edges():
             warnings.warn(f"There is no speedup from leveraging the symmetries in lightcone structure, size of the largest lightcone: {maxnnodes_lightcone}\n Use QAOASimulator instead", RuntimeWarning)
 

--- a/qtensor/QAOASimulator.py
+++ b/qtensor/QAOASimulator.py
@@ -111,11 +111,12 @@ class QAOASimulator(Simulator):
            return C
 
 class QAOASimulatorSymmetryAccelerated(QAOASimulator):
-    def energy_expectation(self, G, gamma, beta):
+    def energy_expectation(self, G, gamma, beta, nprocs=None):
         """
         Arguments:
             G: MaxCut graph, Networkx
             gamma, beta: list[float]
+            nprocs: int (number of processes to use for lightcone orbit computation)
 
         Returns: MaxCut energy expectation
         """
@@ -123,7 +124,7 @@ class QAOASimulatorSymmetryAccelerated(QAOASimulator):
         p = len(gamma)
         assert(len(beta) == p)
 
-        eorbits, _ = get_edge_orbits_lightcones(G,p)
+        eorbits = get_edge_orbits_lightcones(G,p, nprocs)
         if len(eorbits) == G.number_of_edges():
             warnings.warn(f"There is no speedup from leveraging the symmetries in lightcone structure, size of the largest lightcone: {maxnnodes_lightcone}\n Use QAOASimulator instead", RuntimeWarning)
 

--- a/qtensor/tests/test_lightcone_orbits.py
+++ b/qtensor/tests/test_lightcone_orbits.py
@@ -15,3 +15,17 @@ def test_lightcone_energy_value():
     E2 = sym.energy_expectation(G, gamma, beta)
 
     assert(np.isclose(E,E2))
+
+@pytest.mark.skip(reason='pynauty throws "Illegal instruction" on gh actions')
+def test_lightcone_energy_value_large():
+    # large graph should trigger parallel evaluation of lightcone orbits
+    G = nx.random_regular_graph(3, 1000, seed=42)
+    gamma, beta = [np.pi/3], [np.pi/2]
+
+    E = QAOA_energy(G, gamma, beta)
+
+    sym = QAOAQtreeSimulatorSymmetryAccelerated(QtreeQAOAComposer)
+
+    E2 = sym.energy_expectation(G, gamma, beta)
+
+    assert(np.isclose(E,E2))

--- a/qtensor/tests/test_lightcone_orbits.py
+++ b/qtensor/tests/test_lightcone_orbits.py
@@ -26,6 +26,6 @@ def test_lightcone_energy_value_large():
 
     sym = QAOAQtreeSimulatorSymmetryAccelerated(QtreeQAOAComposer)
 
-    E2 = sym.energy_expectation(G, gamma, beta)
+    E2 = sym.energy_expectation(G, gamma, beta, nprocs=8)
 
     assert(np.isclose(E,E2))


### PR DESCRIPTION
Now the light cones are computed in parallel using Python multiprocessing. Speedup on my laptop (8 cores, 16 threads): 

```
Serial:  
         
For |V|=100, |E|=150 and p=6, finished in 0.19s, # lightcones: 150
For |V|=1000, |E|=1500 and p=6, finished in 8.63s, # lightcones: 1500
For |V|=10000, |E|=15000 and p=6, finished in 225.67s, # lightcones: 1991
For |V|=100000, |E|=150000 and p=6, finished in 3314.88s, # lightcones: 278
         
Parallel 16 threads:

For |V|=100, |E|=150 and p=6, finished in 0.20s, # lightcones: 150
For |V|=1000, |E|=1500 and p=6, finished in 4.86s, # lightcones: 1500
For |V|=10000, |E|=15000 and p=6, finished in 40.62s, # lightcones: 1991
For |V|=100000, |E|=150000 and p=6, finished in 488.94s, # lightcones: 278
```

Please note that to use this in production you would have to add `energy_expectation_parallel` and/or `energy_expectation_mpi` to `QAOASimulatorSymmetryAccelerated`. This can be done by changing 

```python
args = [(G, gamma, beta, edge) for edge in G.edges()]
```

to

```python
args = [(G, gamma, beta, orb_edges[0]) for _, orb_edges in eorbits.items()]
```

I think the rest should just work, but please do test it. Then you should be good to go to use this in experiments.

Regarding the issues you've been having with tests in Github actions -- have you tried `pynauty==1.0.0`? We've been having similar issues in a different project and pinning the version helped.